### PR TITLE
Fixes out of memory exception

### DIFF
--- a/browser.Dockerfile
+++ b/browser.Dockerfile
@@ -9,6 +9,9 @@ WORKDIR /home/theia
 # Copy repository files
 COPY . .
 
+# Increase memory for node's Javascript engine
+ENV NODE_OPTIONS='--max_old_space_size=4096'
+
 # Remove unnecesarry files for the browser application
 # Download plugins and build application production mode
 # Use yarn autoclean to remove unnecessary files from package dependencies


### PR DESCRIPTION
When building the docker image under Windows then there is an exception `JavaScript heap out of memory`. Settings the environment variable NODE_OPTIONS gives more memory to the JavaScript engine.

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Review checklist

- [ ] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

